### PR TITLE
Mark buttons as non-draggable in CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -238,6 +238,8 @@ img {
   #panel .minimize {
     left: 30px;
     line-height: 38px; }
+  #panel div {
+    -webkit-app-region: no-drag; }
 
 .city {
   -webkit-box-flex: 1;
@@ -410,6 +412,7 @@ input[type=checkbox] {
     padding: 0; } }
 
 #settings {
+  -webkit-app-region: no-drag;
   background: #333;
   font-family: "Ubuntu Condensed";
   color: #fff;

--- a/css/main.scss
+++ b/css/main.scss
@@ -314,6 +314,9 @@ img {
         left: 30px;
         line-height: 38px;
     }
+    div {
+        -webkit-app-region: no-drag;
+    }
 }
 
 .city {
@@ -525,6 +528,7 @@ input[type=checkbox] {
 }
 
 #settings {
+    -webkit-app-region: no-drag;
     background: #333;
     font-family: "Ubuntu Condensed";
     color: #fff;


### PR DESCRIPTION
On Windows areas marked as draggable can not be clicked, so users cannot click on buttons on Windows.
